### PR TITLE
Fix D-Bus TCP connection leak in testVenusConnectivity()

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,10 +196,21 @@ export default function(app) {
           
           return false;
         } finally {
-          // Always disconnect the test bus
+          // Always disconnect the test bus - must destroy underlying TCP socket
           if (testBus) {
             try {
-              testBus.end();
+              // The dbus-native library end() does not close the TCP socket
+              // Must destroy the underlying connection to prevent leak
+              if (testBus.connection) {
+                if (typeof testBus.connection.destroy === 'function') {
+                  testBus.connection.destroy();
+                } else if (typeof testBus.connection.end === 'function') {
+                  testBus.connection.end();
+                }
+              }
+              if (typeof testBus.end === 'function') {
+                testBus.end();
+              }
             } catch (disconnectErr) {
               // Silent disconnect error handling
             }


### PR DESCRIPTION
## Summary

Fixes the TCP connection leak reported in #7. The `testVenusConnectivity()` function runs every 2 minutes but was not properly closing the D-Bus TCP connection, causing connections to accumulate indefinitely.

## Root Cause

The `dbus-native` library's `end()` method does not close the underlying TCP socket. Calling `testBus.end()` only signals end-of-stream but leaves the socket open.

## The Fix

Before calling `testBus.end()`, we now destroy the underlying TCP connection:

```javascript
if (testBus.connection) {
  if (typeof testBus.connection.destroy === 'function') {
    testBus.connection.destroy();
  } else if (typeof testBus.connection.end === 'function') {
    testBus.connection.end();
  }
}
```

This follows the same pattern already used in `vedbus.js:_forceCloseConnection()`.

## Testing

Tested on Raspberry Pi 4 running OpenPlotter (Debian Bookworm) connecting to Venus OS 3.66 over TCP.

**Before fix (after 4 days uptime):**
| Metric | Value |
|--------|-------|
| TCP connections to Venus | 2,163 (growing ~1 every 2 min) |
| SignalK RSS memory | 2,293 MB |
| File descriptors | 2,349 |
| System available RAM | 634 MB |

**After fix (monitored for 7.5 minutes, 3-4 connectivity test cycles):**
| Metric | Value |
|--------|-------|
| TCP connections to Venus | 5 (stable) |
| SignalK RSS memory | 323 MB (stable) |
| File descriptors | 83-84 (stable) |
| System available RAM | 2.5 GB |

## Checklist

- [x] Fix applied and tested on real hardware
- [x] Connections remain stable after multiple connectivity test cycles
- [x] Memory usage remains stable
- [x] No breaking changes to existing functionality

Fixes #7